### PR TITLE
Allow boolean values

### DIFF
--- a/lib/multipartform.js
+++ b/lib/multipartform.js
@@ -87,7 +87,7 @@ Part.prototype = {
   	  valueSize = this.value.fileSize;
   	} else if (this.value.data) {
   	  valueSize = this.value.data.length;
-        } else if (typeof this.value === 'number') {
+        } else if (typeof this.value === 'number' || typeof this.value === 'boolean') {
           valueSize = this.value.toString().length;
   	} else {
   	  valueSize = this.value.length;


### PR DESCRIPTION
Currently this fails:

```
restler.post('http://localhost:8080', {
  someValue: true
})
```

with this error: `Building multipart request without Content-Length header, please specify all file sizes` 

I have found that this is because restler tries to calculate the content length, and tries to do `total += true.length`.
This causes the total length to be `NaN` and throws the error.